### PR TITLE
Bump pronto to match pronto-rubocop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in pronto-simplecov.gemspec
 gemspec
-gem 'pronto', github: 'dsander/pronto', branch: 'ruby-3.0'

--- a/pronto-simplecov.gemspec
+++ b/pronto-simplecov.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
 
-  spec.add_dependency('pronto', '~> 0.10.0')
+  spec.add_dependency('pronto', '~> 0.11.0')
   spec.add_dependency('simplecov')
   spec.add_development_dependency "bundler", "~> 2"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
`pronto-rubocop` already requires pronto `~> 0.11.0`.