### PR TITLE
Define test repo as module.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "spec/data/test"]
+    path = spec/data/test
+    url = spec/data/test.git


### PR DESCRIPTION
The change allows `pronto-simplecov` to be included in a Gemfile with
```ruby
gem 'pronto_simplecov', github: 'dsander/pronto-simplecov'', branch: 'master'
```
before bundle failed with:
```
fatal: No url found for submodule path 'spec/data/test' in .gitmodules
```